### PR TITLE
Implement lazily filtered get_latest_frame ROS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ When upgrading the base version (from Intel), keep NoMagic's version unchanged.
 
 ### Changelog:
 
+#### 0.2.0
+
+- Feature: implemented get_latest_frame service using lazy filtering.
+
 #### 0.1.1
 
 - Bugfix: Add delay between publishing `/diagnostics` messages to avoid loosing them in the publisher's queue.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ When upgrading the base version (from Intel), keep NoMagic's version unchanged.
 #### 0.2.0
 
 - Feature: implemented get_latest_frame service using lazy filtering.
+Note: to enable it, pass roslaunch argument nomagic_lazy_filtering:=true
+Warning: This change causes filtering to be done only when depth image topics is subscribed.
+Warning: Make sure that image topics are either used continuously (no subscribe, get image, unsubscribe pattern) or not at all. 
 
 #### 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ When upgrading the base version (from Intel), keep NoMagic's version unchanged.
 
 #### 0.1.1
 
-- Bugfix: Add delay between publishing `/diagnostics` messages to avoid loosing them in the publisher's queue.
+- Bugfix: Fix dropping `/diagnostics` messages.
+The bug is caused by the size of the publisher's queue of the aformentioned topic in the implementation of diagnostic_updater.
 It actually happened during testing and caused false-positive health-check failure. 
+Too many calls to update diagnostics seems to overflow the outcoming message queue.
+To avoid this problem, this version introduces short sleeps in the thread that generates diagnostics
+and discontinues using diagnostic_updater::Updater::update() (which is lazy) in favor of the eager version - force_update() 
 
 #### 0.1.0
 - Bugfix: Publish missing `/diagnostics` messages for aligned depth streams.

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -70,6 +70,11 @@ add_message_files(
     Extrinsics.msg
     )
 
+add_service_files(
+    FILES
+    GetLatestFrame.srv
+)
+
 generate_messages(
     DEPENDENCIES
     sensor_msgs

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -338,6 +338,8 @@ namespace realsense2_camera
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;
 
+        std::set<stream_index_pair> nomagic_expected_streams;
+
         // The nomagic_frameset_queue is written from the librealsense callback thread (frame_callback)
         // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)
         std::mutex nomagic_frameset_queue_mutex;
@@ -346,13 +348,13 @@ namespace realsense2_camera
         void nomagicSetup();
         void nomagicGetParameters();
         void nomagicResetTemporalFilter();
-        bool nomagicIsFramesetComplete(const rs2::frameset& frameset);
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
         void nomagicStoreFramesetForLazyProcessing(rs2::frameset);
         bool nomagicGetLatestFrameCallback(stream_index_pair stream, bool is_aligned_depth, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
         void nomagicSetupService(stream_index_pair stream, bool is_aligned_depth);
-        rs2::frame nomagicAlignFrameToDepth(stream_index_pair stream, rs2::frameset frameset);
+        rs2::frame nomagicGetDepthAlignedTo(stream_index_pair stream, rs2::frameset frameset);
         rs2::frame nomagicFramesetToFrame(stream_index_pair stream, rs2::frameset frameset);
+        std::string nomagicFramesetDescriptionString(const rs2::frameset& frameset);
         rs2::frameset nomagicApplyFilters(boost::circular_buffer<rs2::frameset>&& queue);
         sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame frame);
         boost::circular_buffer<rs2::frameset> nomagicGetNonEmptyFramesetQueue();

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -248,12 +248,14 @@ namespace realsense2_camera
         void publish_frequency_update();
 
         void nomagicSetup();
-        bool nomagicGetLatestFrameCallback(stream_index_pair stream, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
+        bool nomagicGetLatestFrameCallback(stream_index_pair stream, bool is_aligned_depth, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
         sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame& frame);
         void nomagicResetTemporalFilter();
         void nomagicApplyFiltersToFrame(rs2::frame& frame);
         void nomagicStoreFramesetForLazyProcessing(rs2::frameset&);
+        void nomagicSetupService(stream_index_pair stream, bool is_aligned_depth);
+        void nomagicAlignFrameToDepth(rs2::frameset& frameset);
 
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;
@@ -338,11 +340,13 @@ namespace realsense2_camera
 
         bool nomagic_lazy_frame_filtering = true;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
+        std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;
 
         // Frame queues are accessed from multiple threads,
         // but don't need external synchronization
         // as their methods are thread-safe.
         std::map<stream_index_pair, rs2::frame_queue> nomagic_frame_queue;
+        std::map<stream_index_pair, rs2::frame_queue> nomagic_aligned_frame_queue;
     };//end class
 
 }

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -248,18 +248,6 @@ namespace realsense2_camera
         void publish_temperature();
         void publish_frequency_update();
 
-        void nomagicSetup();
-        bool nomagicGetLatestFrameCallback(stream_index_pair stream, bool is_aligned_depth, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
-        bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
-        sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame frame);
-        void nomagicResetTemporalFilter();
-        rs2::frameset nomagicApplyFilters(boost::circular_buffer<rs2::frameset>&& queue);
-        void nomagicStoreFramesetForLazyProcessing(rs2::frameset);
-        void nomagicSetupService(stream_index_pair stream, bool is_aligned_depth);
-        rs2::frame nomagicAlignFrameToDepth(stream_index_pair stream, rs2::frameset frameset);
-        boost::circular_buffer<rs2::frameset> nomagicGetNonEmptyFramesetQueue();
-        rs2::frame nomagicFramesetToFrame(stream_index_pair stream, rs2::frameset frameset);
-
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;
         std::map<std::string, std::function<void(rs2::frame)>> _sensors_callback;
@@ -341,13 +329,31 @@ namespace realsense2_camera
         sensor_msgs::PointCloud2 _msg_pointcloud;
         std::vector< unsigned int > _valid_pc_indices;
 
+        // NOMAGIC
+
         bool nomagic_skip_spatial_filter_for_inner_frames = true;
         bool nomagic_lazy_frame_filtering = true;
+
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;
 
+        // The nomagic_frameset_queue is written from the librealsense callback thread (frame_callback)
+        // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)
         std::mutex nomagic_frameset_queue_mutex;
             boost::circular_buffer<rs2::frameset> nomagic_frameset_queue;
+
+        void nomagicSetup();
+        void nomagicResetTemporalFilter();
+        bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
+        void nomagicStoreFramesetForLazyProcessing(rs2::frameset);
+        bool nomagicGetLatestFrameCallback(stream_index_pair stream, bool is_aligned_depth, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
+        void nomagicSetupService(stream_index_pair stream, bool is_aligned_depth);
+        rs2::frame nomagicAlignFrameToDepth(stream_index_pair stream, rs2::frameset frameset);
+        rs2::frame nomagicFramesetToFrame(stream_index_pair stream, rs2::frameset frameset);
+        rs2::frameset nomagicApplyFilters(boost::circular_buffer<rs2::frameset>&& queue);
+        sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame frame);
+        boost::circular_buffer<rs2::frameset> nomagicGetNonEmptyFramesetQueue();
+
     };//end class
 
 }

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -251,6 +251,9 @@ namespace realsense2_camera
         bool nomagicGetLatestFrameCallback(stream_index_pair stream, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
         sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame& frame);
+        void nomagicResetTemporalFilter();
+        void nomagicApplyFiltersToFrame(rs2::frame& frame);
+        void nomagicStoreFramesetForLazyProcessing(rs2::frameset&);
 
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -343,8 +343,10 @@ namespace realsense2_camera
         // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)
         std::mutex nomagic_frameset_queue_mutex;
             boost::circular_buffer<rs2::frameset> nomagic_frameset_queue;
-            int32_t nomagic_all_framesets_count_last_period;
-            int32_t nomagic_incomplete_framesets_count_last_period;
+            int32_t nomagic_framesets_last_period;
+            int32_t nomagic_incomplete_framesets_last_period;
+            int32_t nomagic_missing_depth_framesets_last_period;
+            int32_t nomagic_missing_color_framesets_last_period;
 
         diagnostic_updater::Updater nomagic_frameset_fragmentation_diagnostics;
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -251,13 +251,14 @@ namespace realsense2_camera
         void nomagicSetup();
         bool nomagicGetLatestFrameCallback(stream_index_pair stream, bool is_aligned_depth, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
-        sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame& frame);
+        sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame frame);
         void nomagicResetTemporalFilter();
         rs2::frameset nomagicApplyFilters(boost::circular_buffer<rs2::frameset>&& queue);
-        void nomagicStoreFramesetForLazyProcessing(rs2::frameset&);
+        void nomagicStoreFramesetForLazyProcessing(rs2::frameset);
         void nomagicSetupService(stream_index_pair stream, bool is_aligned_depth);
-        rs2::frameset nomagicAlignFrameToDepth(stream_index_pair stream, rs2::frameset& frameset);
+        rs2::frame nomagicAlignFrameToDepth(stream_index_pair stream, rs2::frameset frameset);
         boost::circular_buffer<rs2::frameset> nomagicGetNonEmptyFramesetQueue();
+        rs2::frame nomagicFramesetToFrame(stream_index_pair stream, rs2::frameset frameset);
 
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -350,8 +350,10 @@ namespace realsense2_camera
 
         diagnostic_updater::Updater nomagic_frameset_fragmentation_diagnostics;
 
+        rs2::processing_block nomagic_muxer;
+        std::map<stream_index_pair, rs2::frameset> nomagic_latest_frame_buffer;
+
         void nomagicSetup();
-        void nomagicPublishStats();
         void nomagicGetParameters();
         void nomagicResetTemporalFilter();
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
@@ -366,6 +368,7 @@ namespace realsense2_camera
         boost::circular_buffer<rs2::frameset> nomagicGetNonEmptyFramesetQueue();
         std::set<stream_index_pair> nomagicFindMissingStreamsInFrameset(const rs2::frameset& frameset);
         void nomagicFramesetsDiagnosticsCallback(diagnostic_updater::DiagnosticStatusWrapper& status);
+        void nomagicMuxerCallback(rs2::frame frame, rs2::frame_source& src);
 
     };//end class
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -337,15 +337,19 @@ namespace realsense2_camera
 
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;
-
         std::set<stream_index_pair> nomagic_expected_streams;
 
         // The nomagic_frameset_queue is written from the librealsense callback thread (frame_callback)
         // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)
         std::mutex nomagic_frameset_queue_mutex;
             boost::circular_buffer<rs2::frameset> nomagic_frameset_queue;
+            int32_t nomagic_all_framesets_count_last_period;
+            int32_t nomagic_incomplete_framesets_count_last_period;
+
+        diagnostic_updater::Updater nomagic_frameset_fragmentation_diagnostics;
 
         void nomagicSetup();
+        void nomagicPublishStats();
         void nomagicGetParameters();
         void nomagicResetTemporalFilter();
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
@@ -358,6 +362,8 @@ namespace realsense2_camera
         rs2::frameset nomagicApplyFilters(boost::circular_buffer<rs2::frameset>&& queue);
         sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame frame);
         boost::circular_buffer<rs2::frameset> nomagicGetNonEmptyFramesetQueue();
+        std::set<stream_index_pair> nomagicFindMissingStreamsInFrameset(const rs2::frameset& frameset);
+        void nomagicFramesetsDiagnosticsCallback(diagnostic_updater::DiagnosticStatusWrapper& status);
 
     };//end class
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -331,8 +331,9 @@ namespace realsense2_camera
 
         // NOMAGIC
 
+        int  nomagic_lazy_filtering_frame_history_size = 9;
         bool nomagic_skip_spatial_filter_for_inner_frames = true;
-        bool nomagic_lazy_frame_filtering = true;
+        bool nomagic_lazy_filtering = true;
 
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;
@@ -343,7 +344,9 @@ namespace realsense2_camera
             boost::circular_buffer<rs2::frameset> nomagic_frameset_queue;
 
         void nomagicSetup();
+        void nomagicGetParameters();
         void nomagicResetTemporalFilter();
+        bool nomagicIsFramesetComplete(const rs2::frameset& frameset);
         bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
         void nomagicStoreFramesetForLazyProcessing(rs2::frameset);
         bool nomagicGetLatestFrameCallback(stream_index_pair stream, bool is_aligned_depth, GetLatestFrame::Request& request, GetLatestFrame::Response& response);

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -46,7 +46,7 @@ namespace realsense2_camera
 
       void update()
       {
-        diagnostic_updater_.force_update();
+        diagnostic_updater_.force_update();  // Explanation: the changelog for version 0.1.1 in README
       }
 
       double expected_frequency_;
@@ -64,7 +64,7 @@ namespace realsense2_camera
             void update(double crnt_temperaure)
             {
                 _crnt_temp = crnt_temperaure;
-                _updater.force_update();
+                _updater.force_update(); // Explanation: the changelog for version 0.1.1 in README
             }
 
         private:

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -341,6 +341,7 @@ namespace realsense2_camera
         sensor_msgs::PointCloud2 _msg_pointcloud;
         std::vector< unsigned int > _valid_pc_indices;
 
+        bool nomagic_skip_spatial_filter_for_inner_frames = true;
         bool nomagic_lazy_frame_filtering = true;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -333,7 +333,7 @@ namespace realsense2_camera
 
         int  nomagic_lazy_filtering_frame_history_size = 9;
         bool nomagic_skip_spatial_filter_for_inner_frames = true;
-        bool nomagic_lazy_filtering = true;
+        bool nomagic_lazy_filtering = false;
 
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -17,6 +17,8 @@
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <condition_variable>
 
+#include <realsense2_camera/GetLatestFrame.h>
+
 #include <queue>
 #include <mutex>
 #include <atomic>
@@ -245,6 +247,11 @@ namespace realsense2_camera
         void publish_temperature();
         void publish_frequency_update();
 
+        void nomagicSetup();
+        bool nomagicGetLatestFrameCallback(stream_index_pair stream, GetLatestFrame::Request& request, GetLatestFrame::Response& response);
+        bool nomagicFramesetHasSubscribers(const rs2::frameset& frameset);
+        sensor_msgs::ImagePtr nomagicFrameToMessage(stream_index_pair stream, rs2::frame& frame);
+
         rs2::device _dev;
         std::map<stream_index_pair, rs2::sensor> _sensors;
         std::map<std::string, std::function<void(rs2::frame)>> _sensors_callback;
@@ -326,6 +333,13 @@ namespace realsense2_camera
         sensor_msgs::PointCloud2 _msg_pointcloud;
         std::vector< unsigned int > _valid_pc_indices;
 
+        bool nomagic_lazy_frame_filtering = true;
+        std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
+
+        // Frame queues are accessed from multiple threads,
+        // but don't need external synchronization
+        // as their methods are thread-safe.
+        std::map<stream_index_pair, rs2::frame_queue> nomagic_frame_queue;
     };//end class
 
 }

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -371,7 +371,7 @@ namespace realsense2_camera
         std::set<stream_index_pair> nomagicFindMissingStreamsInFrameset(const rs2::frameset& frameset);
         void nomagicFramesetsDiagnosticsCallback(diagnostic_updater::DiagnosticStatusWrapper& status);
         void nomagicMuxerCallback(rs2::frame frame, rs2::frame_source& src);
-
+        double nomagicGetUnixTimestamp();
     };//end class
 
 }

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -343,12 +343,14 @@ namespace realsense2_camera
         // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)
         std::mutex nomagic_frameset_queue_mutex;
             boost::circular_buffer<rs2::frameset> nomagic_frameset_queue;
-            int32_t nomagic_framesets_last_period = 0;
-            int32_t nomagic_incomplete_framesets_last_period = 0;
-            int32_t nomagic_missing_depth_framesets_last_period = 0;
-            int32_t nomagic_missing_color_framesets_last_period = 0;
 
         diagnostic_updater::Updater nomagic_frameset_fragmentation_diagnostics;
+        std::mutex nomagic_diagnostics_mutex;
+            int nomagic_received_framesets_last_period = 0;
+            int nomagic_incomplete_framesets_last_period = 0;
+            int nomagic_missing_depth_framesets_last_period = 0;
+            int nomagic_missing_color_framesets_last_period = 0;
+
 
         rs2::processing_block nomagic_muxer;
         std::map<stream_index_pair, rs2::frameset> nomagic_latest_frame_buffer;

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -46,7 +46,7 @@ namespace realsense2_camera
 
       void update()
       {
-        diagnostic_updater_.update();
+        diagnostic_updater_.force_update();
       }
 
       double expected_frequency_;
@@ -64,7 +64,7 @@ namespace realsense2_camera
             void update(double crnt_temperaure)
             {
                 _crnt_temp = crnt_temperaure;
-                _updater.update();
+                _updater.force_update();
             }
 
         private:

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -343,10 +343,10 @@ namespace realsense2_camera
         // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)
         std::mutex nomagic_frameset_queue_mutex;
             boost::circular_buffer<rs2::frameset> nomagic_frameset_queue;
-            int32_t nomagic_framesets_last_period;
-            int32_t nomagic_incomplete_framesets_last_period;
-            int32_t nomagic_missing_depth_framesets_last_period;
-            int32_t nomagic_missing_color_framesets_last_period;
+            int32_t nomagic_framesets_last_period = 0;
+            int32_t nomagic_incomplete_framesets_last_period = 0;
+            int32_t nomagic_missing_depth_framesets_last_period = 0;
+            int32_t nomagic_missing_color_framesets_last_period = 0;
 
         diagnostic_updater::Updater nomagic_frameset_fragmentation_diagnostics;
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -199,7 +199,7 @@ namespace realsense2_camera
         void setupErrorCallback();
         void setupPublishers();
         void enable_devices();
-        void setupFilters();
+        void setupFilters(std::vector<NamedFilter>&);
         void setupStreams();
         void setBaseTime(double frame_time, bool warn_no_metadata);
         cv::Mat& fix_depth_scale(const cv::Mat& from_image, cv::Mat& to_image);
@@ -338,6 +338,7 @@ namespace realsense2_camera
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_frame_servers;
         std::map<stream_index_pair, ros::ServiceServer> nomagic_get_latest_aligned_frame_servers;
         std::set<stream_index_pair> nomagic_expected_streams;
+        std::vector<NamedFilter> nomagic_filters;
 
         // The nomagic_frameset_queue is written from the librealsense callback thread (frame_callback)
         // and read (copied) from ROS service thread (nomagicGetLatestFrameCallback)

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -98,6 +98,11 @@
   <arg name="unite_imu_method"         default="none"/> <!-- Options are: [none, copy, linear_interpolation] -->
   <arg name="allow_no_texture_points"  default="false"/>
 
+  <arg name="nomagic_lazy_filtering_frame_history_size"    default="9"/>
+  <arg name="nomagic_skip_spatial_filter_for_inner_frames" default="true"/>
+  <arg name="nomagic_lazy_filtering"                       default="true"/>
+
+
 
   <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="$(arg output)" required="$(arg required)"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
@@ -193,6 +198,10 @@
     <param name="initial_reset"            type="bool"   value="$(arg initial_reset)"/>
     <param name="unite_imu_method"         type="str"    value="$(arg unite_imu_method)"/>
     <param name="allow_no_texture_points"  type="bool"   value="$(arg allow_no_texture_points)"/>
+
+    <param name="nomagic_lazy_filtering_frame_history_size"    type="int"  value="$(arg nomagic_lazy_filtering_frame_history_size)"/>
+    <param name="nomagic_skip_spatial_filter_for_inner_frames" type="bool" value="$(arg nomagic_skip_spatial_filter_for_inner_frames)"/>
+    <param name="nomagic_lazy_filtering"                       type="bool" value="$(arg nomagic_lazy_filtering)"/>
 
   </node>
 </launch>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -100,7 +100,7 @@
 
   <arg name="nomagic_lazy_filtering_frame_history_size"    default="9"/>
   <arg name="nomagic_skip_spatial_filter_for_inner_frames" default="true"/>
-  <arg name="nomagic_lazy_filtering"                       default="true"/>
+  <arg name="nomagic_lazy_filtering"                       default="false"/>
 
 
 

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -47,12 +47,12 @@
   <arg name="pointcloud_texture_index"  default="0"/>
 
   <arg name="enable_sync"               default="false"/>
-  <arg name="align_depth"               default="false"/>
+  <arg name="align_depth"               default="true"/>
 
   <arg name="publish_tf"                default="true"/>
   <arg name="tf_publish_rate"           default="0"/>
 
-  <arg name="filters"                   default=""/>
+  <arg name="filters"                   default="spatial"/>
   <arg name="clip_distance"             default="-2"/>
   <arg name="linear_accel_cov"          default="0.01"/>
   <arg name="initial_reset"             default="false"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -62,6 +62,10 @@
   <arg name="publish_odom_tf"           default="true"/>
   <arg name="allow_no_texture_points"   default="false"/>
 
+  <arg name="nomagic_lazy_filtering_frame_history_size"    default="9"/>
+  <arg name="nomagic_skip_spatial_filter_for_inner_frames" default="true"/>
+  <arg name="nomagic_lazy_filtering"                       default="true"/>
+
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
@@ -124,6 +128,11 @@
       <arg name="calib_odom_file"          value="$(arg calib_odom_file)"/>
       <arg name="publish_odom_tf"          value="$(arg publish_odom_tf)"/>
       <arg name="allow_no_texture_points"  value="$(arg allow_no_texture_points)"/>
+
+      <arg name="nomagic_lazy_filtering_frame_history_size"    value="$(arg nomagic_lazy_filtering_frame_history_size)"/>
+      <arg name="nomagic_skip_spatial_filter_for_inner_frames" value="$(arg nomagic_skip_spatial_filter_for_inner_frames)"/>
+      <arg name="nomagic_lazy_filtering"                       value="$(arg nomagic_lazy_filtering)"/>
+
     </include>
   </group>
 </launch>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -64,7 +64,7 @@
 
   <arg name="nomagic_lazy_filtering_frame_history_size"    default="9"/>
   <arg name="nomagic_skip_spatial_filter_for_inner_frames" default="true"/>
-  <arg name="nomagic_lazy_filtering"                       default="true"/>
+  <arg name="nomagic_lazy_filtering"                       default="false"/>
 
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2638,7 +2638,7 @@ rs2::frameset BaseRealSenseNode::nomagicApplyFilters(boost::circular_buffer<rs2:
         frameset = queue.front(); queue.pop_front();
 
         // Decide if we apply spatial filter for this frame:
-        bool is_inner_frame = (frames_processed == 0 || frames_processed == static_cast<int>(queue.capacity()) - 1);
+        bool is_inner_frame = !(frames_processed == 0 || frames_processed == static_cast<int>(queue.capacity()) - 1);
         bool skip_spatial = nomagic_skip_spatial_filter_for_inner_frames && is_inner_frame;
 
         for (const NamedFilter& named_filter : _filters) {
@@ -2650,6 +2650,7 @@ rs2::frameset BaseRealSenseNode::nomagicApplyFilters(boost::circular_buffer<rs2:
             }
             // Accumulate history in the temporal filter
             frameset.apply_filter(*named_filter._filter);
+            ROS_INFO("[NOMAGIC] Applied filter %s", named_filter._name.c_str());
         }
         frames_processed += 1;
     }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2549,10 +2549,12 @@ void BaseRealSenseNode::nomagicSetup()
         }
     }
 
+    // Setup diagnostics
     nomagic_frameset_fragmentation_diagnostics.add("[NOMAGIC] Framesets Fragmentation Status",
                                                    this, &BaseRealSenseNode::nomagicFramesetsDiagnosticsCallback);
     nomagic_frameset_fragmentation_diagnostics.setHardwareID(_serial_no);
 
+    // Setup muxer
     nomagic_muxer.start([&](rs2::frame frame) {
         nomagicStoreFramesetForLazyProcessing(frame.as<rs2::frameset>());
     });
@@ -2609,12 +2611,12 @@ void BaseRealSenseNode::nomagicMuxerCallback(rs2::frame frame, rs2::frame_source
     }
 
     // At this point we know that we have a frameset with a fresh depth frame
-    // and (possibly historical) other streams, so we can tick aligned depth frequency counters.
+    // and (possibly historical) other streams.
     for (auto&& image_publisher : _depth_aligned_image_publishers) {
         if (missing_streams.find(image_publisher.first) != missing_streams.end()) {
-            // If we find this stream in missing
+            // If we find (color/infra) stream in missing, we know that we did not tick
+            // aligned_depth fps counter in frame_callback path, so we need to do it here.
             image_publisher.second.second->tick();
-
         }
     }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -81,12 +81,12 @@ BaseRealSenseNode::BaseRealSenseNode(ros::NodeHandle& nodeHandle,
                                      ros::NodeHandle& privateNodeHandle,
                                      rs2::device dev,
                                      const std::string& serial_no) :
-        _is_running(true), _base_frame_id(""), _node_handle(nodeHandle),
-        _pnh(privateNodeHandle), _dev(dev), _json_file_path(""),
-        _serial_no(serial_no),
-        _is_initialized_time_base(false),
-        _namespace(getNamespaceStr()),
-        nomagic_muxer([&](rs2::frame f, rs2::frame_source& src) { nomagicMuxerCallback(f, src);})
+    _is_running(true), _base_frame_id(""),  _node_handle(nodeHandle),
+    _pnh(privateNodeHandle), _dev(dev), _json_file_path(""),
+    _serial_no(serial_no),
+    _is_initialized_time_base(false),
+    _namespace(getNamespaceStr()),
+    nomagic_muxer([&](rs2::frame f, rs2::frame_source& src) { nomagicMuxerCallback(f, src);})
 {
     // Types for depth stream
     _format[RS2_STREAM_DEPTH] = RS2_FORMAT_Z16;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2611,7 +2611,11 @@ void BaseRealSenseNode::nomagicMuxerCallback(rs2::frame frame, rs2::frame_source
     // At this point we know that we have a frameset with a fresh depth frame
     // and (possibly historical) other streams, so we can tick aligned depth frequency counters.
     for (auto&& image_publisher : _depth_aligned_image_publishers) {
-        image_publisher.second.second->update();
+        if (missing_streams.find(image_publisher.first) != missing_streams.end()) {
+            // If we find this stream in missing
+            image_publisher.second.second->tick();
+
+        }
     }
 
     src.frame_ready(src.allocate_composite_frame(frames_vec));

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -947,99 +947,6 @@ void BaseRealSenseNode::setupPublishers()
     }
 }
 
-bool BaseRealSenseNode::nomagicFramesetHasSubscribers(const rs2::frameset& frameset) {
-    for (auto it = frameset.begin(); it != frameset.end(); ++it) {
-        auto f = (*it);
-        auto stream_type = f.get_profile().stream_type();
-        auto stream_index = f.get_profile().stream_index();
-        stream_index_pair stream = {stream_type, stream_index};
-        auto& info_publisher = _info_publisher.at(stream);
-        auto& image_publisher = _image_publishers.at(stream);
-
-        bool has_subscribers = (info_publisher.getNumSubscribers() != 0)
-                            || (image_publisher.first.getNumSubscribers() != 0);
-        if (has_subscribers) {
-            return true;
-        }
-    }
-    return false;
-}
-
-void BaseRealSenseNode::nomagicSetup()
-{
-    for (auto& stream : IMAGE_STREAMS) {
-        if (!_enable[stream]) {
-            continue;
-        }
-
-        std::string stream_name(STREAM_NAME(stream)); // infra2
-        std::stringstream service_name;
-        service_name << stream_name << "/get_latest_frame";
-
-        // Trampoline to pass stream parameter.
-        boost::function<bool(GetLatestFrame::Request&, GetLatestFrame::Response&)> callback =
-                [=](GetLatestFrame::Request& request, GetLatestFrame::Response& response) {
-            return nomagicGetLatestFrameCallback(stream, request, response);
-        };
-
-        nomagic_get_latest_frame_servers.insert({stream, _node_handle.advertiseService(service_name.str(), callback)});
-        nomagic_frame_queue.insert({stream, rs2::frame_queue(_fps[stream], true)});
-    }
-
-}
-
-bool BaseRealSenseNode::nomagicGetLatestFrameCallback(stream_index_pair stream,
-                                                      GetLatestFrame::Request& request,
-                                                      GetLatestFrame::Response& response)
-{
-    auto& queue = nomagic_frame_queue[stream];
-
-    rs2::frame frame;
-    while (queue.poll_for_frame(&frame)) {
-        assert(frame.is<rs2::frameset>());
-        for (const NamedFilter& named_filter : _filters) {
-            frame = named_filter._filter->process(frame);
-        }
-    }
-
-    response.image = *nomagicFrameToMessage(stream, frame);
-    return true;
-}
-
-sensor_msgs::ImagePtr BaseRealSenseNode::nomagicFrameToMessage(stream_index_pair stream, rs2::frame& frame) {
-    // This code is a refactored chunk of publishFrame.
-
-
-    assert(frame.is<rs2::video_frame>());
-    assert(false);
-
-    auto vframe = frame.as<rs2::video_frame>();
-    auto width = vframe.get_width();
-    auto height = vframe.get_height();
-    auto bpp = vframe.get_bytes_per_pixel();
-    auto& buffer = _image[stream];
-
-    buffer.create(height, width, buffer.type()); // This is lazy and won't reallocate if not needed.
-    buffer.data = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(frame.get_data()));
-
-    if (frame.is<rs2::depth_frame>()) {
-        // Note: fix_depth_scale returns it's second argument
-        // TODO: probably a deep copy is done here, should be easy to optimize it out
-        buffer = fix_depth_scale(buffer, _depth_scaled_image[stream]);
-    }
-
-    sensor_msgs::ImagePtr img;
-    img = cv_bridge::CvImage(std_msgs::Header(), _encoding.at(stream.first), buffer).toImageMsg();
-    img->width = width;
-    img->height = height;
-    img->is_bigendian = false;
-    img->step = width * bpp;
-    img->header.frame_id = _optical_frame_id.at(stream); // Not sure about this, but probably it does not matter for us.
-    img->header.stamp = ros::Time::now(); // This is a simplification, does not handle case when _sync_frames == false
-
-    return img;
-}
-
 void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t)
 {
     for (auto it = frames.begin(); it != frames.end(); ++it)
@@ -2586,4 +2493,132 @@ void TemperatureDiagnostics::diagnostics(diagnostic_updater::DiagnosticStatusWra
 {
         status.summary(0, "OK");
         status.add("Index", _crnt_temp);
+}
+
+/****************************** NOMAGIC ******************************/
+
+struct Clock
+{
+    using InternalClock = std::chrono::steady_clock;
+
+    Clock() : start(InternalClock::now()) {}
+    void restart() {
+        start = InternalClock::now();
+    }
+
+    double getElapsedSecs() {
+        return static_cast<std::chrono::duration<double>>(InternalClock::now() - start).count();
+    }
+
+private:
+    InternalClock::time_point start;
+};
+
+
+void BaseRealSenseNode::nomagicSetup()
+{
+    for (auto& stream : IMAGE_STREAMS) {
+        if (!_enable[stream]) {
+            continue;
+        }
+
+        std::string stream_name(STREAM_NAME(stream)); // infra2
+        std::stringstream service_name;
+        service_name << stream_name << "/get_latest_frame";
+
+        // Trampoline to pass stream parameter.
+        boost::function<bool(GetLatestFrame::Request&, GetLatestFrame::Response&)> callback =
+                [=](GetLatestFrame::Request& request, GetLatestFrame::Response& response) {
+            return nomagicGetLatestFrameCallback(stream, request, response);
+        };
+
+        nomagic_get_latest_frame_servers.insert({stream, _node_handle.advertiseService(service_name.str(), callback)});
+        nomagic_frame_queue.insert({stream, rs2::frame_queue(10, true)});
+    }
+
+}
+
+bool BaseRealSenseNode::nomagicFramesetHasSubscribers(const rs2::frameset& frameset) {
+    for (auto it = frameset.begin(); it != frameset.end(); ++it) {
+        auto f = (*it);
+        auto stream_type = f.get_profile().stream_type();
+        auto stream_index = f.get_profile().stream_index();
+        stream_index_pair stream = {stream_type, stream_index};
+        auto& info_publisher = _info_publisher.at(stream);
+        auto& image_publisher = _image_publishers.at(stream);
+
+        bool has_subscribers = (info_publisher.getNumSubscribers() != 0)
+                            || (image_publisher.first.getNumSubscribers() != 0);
+        if (has_subscribers) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool BaseRealSenseNode::nomagicGetLatestFrameCallback(stream_index_pair stream,
+                                                      GetLatestFrame::Request& request,
+                                                      GetLatestFrame::Response& response)
+{
+    Clock clock;
+    Clock all;
+
+
+    auto& queue = nomagic_frame_queue[stream];
+    std::cout << "Queue: " << clock.getElapsedSecs() << std::endl;
+
+    int count = 0;
+    rs2::frame frame;
+    all.restart();
+    clock.restart();
+    while (queue.poll_for_frame(&frame)) {
+        std::cout << "Polling " << clock.getElapsedSecs() << std::endl;
+        assert(frame.is<rs2::frameset>());
+        for (const NamedFilter& named_filter : _filters) {
+            clock.restart();
+            frame = named_filter._filter->process(frame);
+            std::cout << "Filter " << named_filter._name << ": " << clock.getElapsedSecs() << std::endl;
+        }
+        count += 1;
+    }
+    std::cout << "Filtering ALL: " << all.getElapsedSecs() << std::endl;
+    std::cout << "Frames: " << count << std::endl;
+    std::cout << "=======================================" << std::endl;
+
+    response.image = *nomagicFrameToMessage(stream, frame);
+    return true;
+}
+
+sensor_msgs::ImagePtr BaseRealSenseNode::nomagicFrameToMessage(stream_index_pair stream, rs2::frame& frame) {
+    // This code is a refactored chunk of publishFrame.
+
+
+    assert(frame.is<rs2::video_frame>());
+    assert(false);
+
+    auto vframe = frame.as<rs2::video_frame>();
+    auto width = vframe.get_width();
+    auto height = vframe.get_height();
+    auto bpp = vframe.get_bytes_per_pixel();
+    auto& buffer = _image[stream];
+
+    buffer.create(height, width, buffer.type()); // This is lazy and won't reallocate if not needed.
+    buffer.data = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(frame.get_data()));
+
+    if (frame.is<rs2::depth_frame>()) {
+        // Note: fix_depth_scale returns it's second argument
+        // TODO: probably a deep copy is done here, should be easy to optimize it out
+        buffer = fix_depth_scale(buffer, _depth_scaled_image[stream]);
+    }
+
+    sensor_msgs::ImagePtr img;
+    img = cv_bridge::CvImage(std_msgs::Header(), _encoding.at(stream.first), buffer).toImageMsg();
+    img->width = width;
+    img->height = height;
+    img->is_bigendian = false;
+    img->step = width * bpp;
+    img->header.frame_id = _optical_frame_id.at(stream); // Not sure about this, but probably it does not matter for us.
+    img->header.stamp = ros::Time::now(); // This is a simplification, does not handle case when _sync_frames == false
+
+    return img;
 }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2781,6 +2781,7 @@ bool BaseRealSenseNode::nomagicIsFramesetComplete(const rs2::frameset& frameset)
             missing << rs2_stream_to_string(stream.first) << stream.second << ", ";
         }
         // This is rather harmless, increases latency and hard to fix.
+        // However, if you receive a lot of these notification, try to replug the camera :)
         ROS_WARN_STREAM("[NOMAGIC] Received an incomplete frameset, missing: " << missing.str());
     }
     return required.empty();

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2871,6 +2871,7 @@ void BaseRealSenseNode::nomagicStoreFramesetForLazyProcessing(rs2::frameset fram
 
 boost::circular_buffer<rs2::frameset> BaseRealSenseNode::nomagicGetNonEmptyFramesetQueue()
 {
+    int times_waited = 0;
     while (true) {
         {
             std::lock_guard<std::mutex> lock(nomagic_frameset_queue_mutex);
@@ -2879,6 +2880,11 @@ boost::circular_buffer<rs2::frameset> BaseRealSenseNode::nomagicGetNonEmptyFrame
             }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        times_waited += 1;
+        if (times_waited > 1) {
+            // This message may indicate too high CPU load (or some mysterious concurrency bug ;))
+            ROS_WARN("[NOMAGIC] Waited for locking frameset queue %d times", times_waited);
+        }
     }
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2631,7 +2631,7 @@ rs2::frameset BaseRealSenseNode::nomagicApplyFilters(boost::circular_buffer<rs2:
         frameset = queue.front(); queue.pop_front();
 
         // Decide if we apply spatial filter for this frame:
-        bool is_inner_frame = (frames_processed == 0 || frames_processed == queue.capacity() - 1);
+        bool is_inner_frame = (frames_processed == 0 || frames_processed == static_cast<int>(queue.capacity()) - 1);
         bool skip_spatial = nomagic_skip_spatial_filter_for_inner_frames && is_inner_frame;
 
         for (const NamedFilter& named_filter : _filters) {

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2601,9 +2601,17 @@ rs2::frameset BaseRealSenseNode::nomagicApplyFilters(boost::circular_buffer<rs2:
     while (!queue.empty()) {
         frameset = queue.front(); queue.pop_front();
 
+        // Decide if we apply spatial filter for this frame:
+        bool apply_spatial = nomagic_skip_spatial_filter_for_inner_frames
+                           ? (frames_processed == 0 || frames_processed == queue.capacity() - 1)
+                           : false;
         for (const NamedFilter& named_filter : _filters) {
             // It may look like we're overwriting the frame here
             // but the 'real' purpose is to accumulate sufficient history in the temporal filter
+            if (!apply_spatial && named_filter._name == "spatial") {
+                continue;
+            }
+            printf("Applying filter %s\n", named_filter._name.c_str());
             frameset = named_filter._filter->process(frameset);
         }
         frames_processed += 1;

--- a/realsense2_camera/srv/GetLatestFrame.srv
+++ b/realsense2_camera/srv/GetLatestFrame.srv
@@ -1,0 +1,2 @@
+---
+sensor_msgs/Image image

--- a/realsense2_camera/srv/GetLatestFrame.srv
+++ b/realsense2_camera/srv/GetLatestFrame.srv
@@ -1,2 +1,10 @@
 ---
 sensor_msgs/Image image
+float64 frame_timestamp
+float64 request_timestamp
+float64 response_timestamp
+
+float64 wait_for_frames_duration
+float64 reset_temporal_filter_duration
+float64 filtering_duration
+float64 depth_alignment_duration


### PR DESCRIPTION
This pull request implements a number of services that return the latest frame of an appropriate stream (color, depth, infra{1|2}, aligned_depth_to_{color|infra}.

The main goal of these changes is to reduce CPU usage which is mostly caused by two filters (spatial and temporal) that significantly improve depth image quality. Reduction of CPU usage is critical for using dozens of cameras on a single computer.

Unfortunately, the temporal filter is stateful - it depends on all past frames to smooth the noise in time and on 8 previous to fill holes in the current frame.

Because two consecutive calls of the get_latest_frame may distant in time, it is necessary to rebuild the temporal's filter state to a sufficient degree. This is done by maintaining a circular buffer of a couple of the most recent frames and processing them all at once when the service is called.

I'd recommend starting the review from the base_realsense_node.h to learn about data structures, then nomagicSetup, nomagicSetupService, nomagicGetLatestFrameCallback, and then wherever the callgraph leads you ;)

Edit: another good way to read the code is to follow the path of a frame - received in the frame_callback, processed in the nomagicMuxerCallback, and then used in the nomagicGetLatestFrameCallback.